### PR TITLE
Update manifest.json

### DIFF
--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -26,5 +26,11 @@
     "48": "icons/Icon-48.png",
     "128": "icons/Icon-128.png"
   },
+  "browser_specific_settings": {
+		"gecko": {
+			"id": "numbers@hand.com",
+			"strict_min_version": "48.0"
+		}
+	},
   "content_security_policy": "script-src 'self' https://ssl.google-analytics.com https://www.google-analytics.com https://www.googletagmanager.com ; object-src 'self'"
 }


### PR DESCRIPTION
Support for Firefox add-on.
Chrome knows and supports this tag as well.